### PR TITLE
release: https://blog.rust-lang.org/2023/06/01/Rust-1.70.0.html

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+rust (1.70.0) jammy; urgency=medium
+
+  * https://blog.rust-lang.org/2023/06/01/Rust-1.70.0.html
+
+ -- Michael Murphy <michael@mmurphy.dev>  Wed, 07 Jun 2023 19:54:55 +0200
+
 rust (1.69.0) jammy; urgency=medium
 
   * https://blog.rust-lang.org/2023/04/20/Rust-1.69.0.html

--- a/debian/rules
+++ b/debian/rules
@@ -1,14 +1,14 @@
 #!/usr/bin/make -f
 
-VERSION=1.69.0
+VERSION=1.70.0
 
 %:
 	dh $@
 
 override_dh_auto_clean:
 	ischroot || bash fetch.sh upstream $(VERSION) \
-		2ca4a306047c0b8b4029c382910fcbc895badc29680e0332c9df990fd1c70d4f \
-		88af5aa7a40c8f1b40416a1f27de8ffbe09c155d933f69d3e109c0ccee92353b
+		8499c0b034dd881cd9a880c44021632422a28dc23d7a81ca0a97b04652245982 \
+		3aa012fc4d9d5f17ca30af41f87e1c2aacdac46b51adc5213e7614797c6fd24c
 #	ischroot || just version=$(VERSION) fetch
 
 override_dh_auto_build:


### PR DESCRIPTION
Some crates are starting to use the stabilized once-cell features.