### PR TITLE
fix: aarch64 link fix

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -15,7 +15,9 @@ override_dh_auto_build:
 
 override_dh_auto_install:
 	just version=$(VERSION) rootdir=debian/tmp install
-	patchelf --add-needed /usr/lib/rustlib/$(DEB_TARGET_GNU_CPU)-unknown-linux-gnu/lib/libLLVM.so.18.1-rust-1.79.0-stable  debian/tmp/usr/bin/rustc
+	if test $(DEB_TARGET_GNU_CPU) = "x86_64"; then \
+		patchelf --add-needed /usr/lib/rustlib/$(DEB_TARGET_GNU_CPU)-unknown-linux-gnu/lib/libLLVM.so.18.1-rust-1.79.0-stable  debian/tmp/usr/bin/rustc; \
+	fi
 
 override_dh_strip:
 


### PR DESCRIPTION
The need to fix the LLVM link may only apply to x86_64.