### PR TITLE
Run `patchelf` regardless of architecture

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -15,12 +15,10 @@ override_dh_auto_build:
 
 override_dh_auto_install:
 	just version=$(VERSION) rootdir=debian/tmp install
-	if test $(DEB_TARGET_GNU_CPU) = "x86_64"; then \
-		patchelf --add-needed /usr/lib/rustlib/$(DEB_TARGET_GNU_CPU)-unknown-linux-gnu/lib/libLLVM.so.20.1-rust-$(VERSION)-stable  debian/tmp/usr/bin/cargo-clippy; \
-		patchelf --add-needed /usr/lib/rustlib/$(DEB_TARGET_GNU_CPU)-unknown-linux-gnu/lib/libLLVM.so.20.1-rust-$(VERSION)-stable  debian/tmp/usr/bin/clippy-driver; \
-		patchelf --add-needed /usr/lib/rustlib/$(DEB_TARGET_GNU_CPU)-unknown-linux-gnu/lib/libLLVM.so.20.1-rust-$(VERSION)-stable  debian/tmp/usr/bin/rustc; \
-		patchelf --add-needed /usr/lib/rustlib/$(DEB_TARGET_GNU_CPU)-unknown-linux-gnu/lib/libLLVM.so.20.1-rust-$(VERSION)-stable  debian/tmp/usr/bin/rustfmt; \
-	fi
+	patchelf --add-needed /usr/lib/rustlib/$(DEB_TARGET_GNU_CPU)-unknown-linux-gnu/lib/libLLVM.so.20.1-rust-$(VERSION)-stable  debian/tmp/usr/bin/cargo-clippy; \
+	patchelf --add-needed /usr/lib/rustlib/$(DEB_TARGET_GNU_CPU)-unknown-linux-gnu/lib/libLLVM.so.20.1-rust-$(VERSION)-stable  debian/tmp/usr/bin/clippy-driver; \
+	patchelf --add-needed /usr/lib/rustlib/$(DEB_TARGET_GNU_CPU)-unknown-linux-gnu/lib/libLLVM.so.20.1-rust-$(VERSION)-stable  debian/tmp/usr/bin/rustc; \
+	patchelf --add-needed /usr/lib/rustlib/$(DEB_TARGET_GNU_CPU)-unknown-linux-gnu/lib/libLLVM.so.20.1-rust-$(VERSION)-stable  debian/tmp/usr/bin/rustfmt; \
 
 override_dh_strip:
 


### PR DESCRIPTION
I'm not sure why this was x86_64 exclusive, but the recent arm64 binaries for 1.89.0 seem to be failing at finding this library.

Testing locally on my Pinebook Pro, this does seem to make the executables start as they should.