### PR TITLE
Rust 1.90

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+rust (1.90.0) jammy; urgency=medium
+
+  * https://blog.rust-lang.org/2025/09/18/Rust-1.90.0/
+  * Significant reduction in compile times
+
+ -- Michael Murphy <michael@mmurphy.dev>  Mon, 29 Sep 2025 15:54:28 +0200
+
 rust (1.89.0) jammy; urgency=medium
 
   * https://blog.rust-lang.org/2025/08/07/Rust-1.89.0/

--- a/debian/rules
+++ b/debian/rules
@@ -1,14 +1,14 @@
 #!/usr/bin/make -f
 
-VERSION=1.89.0
+VERSION=1.90.0
 
 %:
 	dh $@
 
 override_dh_auto_clean:
 	ischroot || bash fetch.sh upstream $(VERSION) \
-		c4f2796b10ee886001f0799bc40caea38746403a33c379d77878c4f4683f9b51 \
-		ae6f35b027cb32339fa4ac94dab37a21194e9a5c680491d01e54aa61e9da4de7
+		bff8974f2d3ee6c0e6ac926b533f65bbdd3697d2c2b925bdae5f45b9eed10a67 \
+		59f1883fcdd2d7243d2fd1ed19f22e05219251227abacfa3d656aebfbcc5e838
 
 override_dh_auto_build:
 	just version=$(VERSION)


### PR DESCRIPTION
https://blog.rust-lang.org/2025/09/18/Rust-1.90.0/

There is a 40% reduction in compile times with the change to the rust-lld linker

https://blog.rust-lang.org/2025/09/01/rust-lld-on-1.90.0-stable/